### PR TITLE
Allow specifying block response in configuration

### DIFF
--- a/example/Corefile
+++ b/example/Corefile
@@ -7,6 +7,7 @@
   blocklist blocklist.txt {
     allowlist allowlist.txt
     domain_metrics
+    block_response refused
   }
 
   forward . 1.1.1.1 1.0.0.1

--- a/setup.go
+++ b/setup.go
@@ -2,10 +2,13 @@ package blocklist
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/coredns/caddy"
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
+
+	"github.com/miekg/dns"
 )
 
 func init() { plugin.Register("blocklist", setup) }
@@ -16,6 +19,7 @@ func setup(c *caddy.Controller) error {
 		var blocklistLocation string
 		var allowlistLocation string
 		var allowlist []string
+		var blockResponse string
 		c.Args(&blocklistLocation)
 
 		if blocklistLocation == "" {
@@ -35,6 +39,14 @@ func setup(c *caddy.Controller) error {
 				log.Debugf("Setting allowlist location to %s", allowlistLocation)
 			case "domain_metrics":
 				domainMetrics = true
+			case "block_response":
+				remaining := c.RemainingArgs()
+				if len(remaining) != 1 {
+					return plugin.Error("blocklist", errors.New("block_response requires a single argument."))
+				}
+
+				blockResponse = remaining[0]
+				log.Debugf("Setting block response code to %s", blockResponse)
 			default:
 				return plugin.Error("blocklist", c.Errf("unexpected '%v' command", option))
 			}
@@ -56,11 +68,30 @@ func setup(c *caddy.Controller) error {
 			}
 		}
 
+		if blockResponse == "" {
+			blockResponse = "nxdomain"
+		}
+		blockResponseCode, err := getBlockResponseCode(blockResponse)
+		if err != nil {
+			return plugin.Error("blocklist", err)
+		}
+
 		dnsserver.GetConfig(c).
 			AddPlugin(func(next plugin.Handler) plugin.Handler {
-				return NewBlocklistPlugin(next, blocklist, allowlist, domainMetrics)
+				return NewBlocklistPlugin(next, blocklist, allowlist, domainMetrics, blockResponseCode)
 			})
 	}
 
 	return nil
+}
+
+func getBlockResponseCode(blockResponse string) (int, error) {
+	switch blockResponse {
+	case "nxdomain":
+		return dns.RcodeNameError, nil
+	case "refused":
+		return dns.RcodeRefused, nil
+	default:
+		return 0, fmt.Errorf("unknown response code '%s', must be either 'nxdomain' or 'refused'", blockResponse)
+	}
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/coredns/caddy"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/miekg/dns"
 )
 
 func TestSetupInvalidConfig(t *testing.T) {
@@ -58,4 +60,55 @@ func TestSetupValidConfig(t *testing.T) {
 	c = caddy.NewTestController("dns", `blocklist https://mirror1.malwaredomains.com/files/justdomains { domain_metrics }`)
 	err = setup(c)
 	assert.NoError(t, err)
+}
+
+func TestSetupValidConfigWithRefusedResponse(t *testing.T) {
+	cfg := `blocklist example/blocklist.txt {
+            block_response refused
+          }`
+	c := caddy.NewTestController("dns", cfg)
+
+	err := setup(c)
+	assert.NoError(t, err)
+}
+
+func TestSetupMissingBlockResponseValue(t *testing.T) {
+	cfg := `blocklist example/blocklist.txt {
+            block_response
+          }`
+	c := caddy.NewTestController("dns", cfg)
+
+	err := setup(c)
+	assert.EqualError(
+		t,
+		err,
+		"plugin/blocklist: block_response requires a single argument.",
+	)
+}
+
+func TestSetupInvalidBlockResponse(t *testing.T) {
+	cfg := `blocklist example/blocklist.txt {
+            block_response invalid
+          }`
+	c := caddy.NewTestController("dns", cfg)
+
+	err := setup(c)
+	assert.Error(t, err)
+	assert.EqualError(
+		t,
+		err,
+		"plugin/blocklist: unknown response code 'invalid', must be either 'nxdomain' or 'refused'",
+	)
+}
+
+func TestSetupNxdomainBlockResponseCode(t *testing.T) {
+	r, err := getBlockResponseCode("nxdomain")
+	assert.NoError(t, err)
+	assert.Equal(t, r, dns.RcodeNameError)
+}
+
+func TestSetupRefusedBlockResponseCode(t *testing.T) {
+	r, err := getBlockResponseCode("refused")
+	assert.NoError(t, err)
+	assert.Equal(t, r, dns.RcodeRefused)
 }


### PR DESCRIPTION
NXDOMAIN is the traditional response code for blocking DNS queries, but can make it difficult to differentiate between actual DNS problems and DNS blocklists. This change introduces the ability to respond with REFUSED instead, to make it easier to identify DNS blocks.

The default behaviour remains to respond with NXDOMAIN, so no additional configuration is required to maintain current behaviour.