### PR TITLE
fix #73: bootstrapDNS

### DIFF
--- a/example/Corefile
+++ b/example/Corefile
@@ -3,7 +3,11 @@
   debug
   prometheus
 
-  blocklist https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts
+  blocklist https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts {
+    # if CoreDNS listens at 53, you need another DNS to bootstrap the download
+    bootstrap_dns 1.1.1.1:53
+  }
+
   blocklist blocklist.txt {
     allowlist allowlist.txt
     domain_metrics

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,11 @@ domain on each line. There is an example file in the example folder.
   prometheus
 
   # load from url
-  blocklist https://mirror1.malwaredomains.com/files/justdomains
+  blocklist https://mirror1.malwaredomains.com/files/justdomains {
+    # if CoreDNS listens at 53, you need another DNS to bootstrap the download
+    bootstrap_dns 1.1.1.1:53
+  }
+
   # load from file, if the path is not absolute it will be relative to the Corefile
   blocklist blocklist.txt
 

--- a/setup.go
+++ b/setup.go
@@ -20,6 +20,7 @@ func setup(c *caddy.Controller) error {
 		var allowlistLocation string
 		var allowlist []string
 		var blockResponse string
+		var bootStrapDNS string
 		c.Args(&blocklistLocation)
 
 		if blocklistLocation == "" {
@@ -39,6 +40,8 @@ func setup(c *caddy.Controller) error {
 				log.Debugf("Setting allowlist location to %s", allowlistLocation)
 			case "domain_metrics":
 				domainMetrics = true
+			case "bootstrap_dns":
+				bootStrapDNS = c.RemainingArgs()[0]
 			case "block_response":
 				remaining := c.RemainingArgs()
 				if len(remaining) != 1 {
@@ -56,13 +59,13 @@ func setup(c *caddy.Controller) error {
 			return plugin.Error("blocklist", errors.New("To many arguments for blocklist."))
 		}
 
-		blocklist, err := loadList(c, blocklistLocation)
+		blocklist, err := loadList(c, blocklistLocation, bootStrapDNS)
 		if err != nil {
 			return plugin.Error("blocklist", err)
 		}
 
 		if allowlistLocation != "" {
-			allowlist, err = loadList(c, allowlistLocation)
+			allowlist, err = loadList(c, allowlistLocation, bootStrapDNS)
 			if err != nil {
 				return plugin.Error("blocklist", err)
 			}


### PR DESCRIPTION
I'm no way familiar with go so there might be mistakes. But it works with  `example/Corefile`.

I found a guide  https://koraygocmen.medium.com/custom-dns-resolver-for-the-default-http-client-in-go-a1420db38a5d to allow custom DNS for http.Get. 